### PR TITLE
Update and fix GameStop and Afterglow wired controllers VID/PID values.

### DIFF
--- a/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.cpp
+++ b/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.cpp
@@ -96,8 +96,8 @@ uint8_t XBOXUSB::Init(uint8_t parent, uint8_t port, bool lowspeed) {
 
         if(VID != XBOX_VID && VID != MADCATZ_VID && VID != JOYTECH_VID && VID != GAMESTOP_VID && VID != MADCATZ_VID1 && VID != AFTERGLOW_VID)
                 goto FailUnknownDevice;
-        if(PID != XBOX_WIRED_PID && PID != MADCATZ_WIRED_PID && PID != GAMESTOP_WIRED_PID &&
-				   PID != AFTERGLOW_WIRED_PID && PID != JOYTECH_WIRED_PID &&
+        if(PID != XBOX_WIRED_PID && PID != MADCATZ_WIRED_PID && PID != GAMESTOP_WIRED_PID1 && PID != GAMESTOP_WIRED_PID2 &&
+				   PID != AFTERGLOW_WIRED_PID1 && PID != AFTERGLOW_WIRED_PID2 && PID != JOYTECH_WIRED_PID &&
 				   PID!= MADCATZ_FIGHTSTICK_PID && PID!= MADCATZ_PID1 && PID!= MADCATZ_PID2)
                 goto FailUnknownDevice;
 

--- a/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.cpp
+++ b/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.cpp
@@ -94,11 +94,12 @@ uint8_t XBOXUSB::Init(uint8_t parent, uint8_t port, bool lowspeed) {
         VID = udd->idVendor;
         PID = udd->idProduct;
 
-        if(VID != XBOX_VID && VID != MADCATZ_VID && VID != JOYTECH_VID && VID != GAMESTOP_VID && VID != MADCATZ_VID1 && VID != AFTERGLOW_VID)
+        if(VID != XBOX_VID && VID != MADCATZ_VID && VID != JOYTECH_VID && VID != GAMESTOP_VID && VID != MADCATZ_VID1 && VID != AFTERGLOW_VID && VID != ROCKCANDY_VID && VID != THRUSTMASTER_GPX_VID)
                 goto FailUnknownDevice;
         if(PID != XBOX_WIRED_PID && PID != MADCATZ_WIRED_PID && PID != GAMESTOP_WIRED_PID1 && PID != GAMESTOP_WIRED_PID2 &&
 				   PID != AFTERGLOW_WIRED_PID1 && PID != AFTERGLOW_WIRED_PID2 && PID != JOYTECH_WIRED_PID &&
-				   PID!= MADCATZ_FIGHTSTICK_PID && PID!= MADCATZ_PID1 && PID!= MADCATZ_PID2)
+				   PID!= MADCATZ_FIGHTSTICK_PID && PID!= MADCATZ_PID1 && PID!= MADCATZ_PID2 && PID != ROCKCANDY_WIRED_PID &&
+				   PID != THRUSTMASTER_GPX_WIRED_PID && PID != THRUSTMASTER_WHEEL_PID)
                 goto FailUnknownDevice;
 
         // Allocate new address according to device class

--- a/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.cpp
+++ b/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.cpp
@@ -94,7 +94,7 @@ uint8_t XBOXUSB::Init(uint8_t parent, uint8_t port, bool lowspeed) {
         VID = udd->idVendor;
         PID = udd->idProduct;
 
-        if(VID != XBOX_VID && VID != MADCATZ_VID && VID != JOYTECH_VID && VID != GAMESTOP_VID && VID != MADCATZ_VID1)
+        if(VID != XBOX_VID && VID != MADCATZ_VID && VID != JOYTECH_VID && VID != GAMESTOP_VID && VID != MADCATZ_VID1 && VID != AFTERGLOW_VID)
                 goto FailUnknownDevice;
         if(PID != XBOX_WIRED_PID && PID != MADCATZ_WIRED_PID && PID != GAMESTOP_WIRED_PID &&
 				   PID != AFTERGLOW_WIRED_PID && PID != JOYTECH_WIRED_PID &&

--- a/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.h
+++ b/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.h
@@ -37,6 +37,8 @@
 #define GAMESTOP_VID                            0x0E6F // Gamestop controller
 #define AFTERGLOW_VID                           0x12AB // Afterglow controller
 #define MADCATZ_VID1                            0x0738 // Gamestop controller
+#define ROCKCANDY_VID							0x24C6 // Rock Candy controller
+#define THRUSTMASTER_GPX_VID					0x24C6 // Thrustmaster gpx controller
 
 #define XBOX_WIRED_PID                          0x028E // Microsoft 360 Wired controller
 #define XBOX_WIRELESS_PID                       0x028F // Wireless controller only support charging
@@ -51,6 +53,9 @@
 #define AFTERGLOW_WIRED_PID2                    0x0302 // Afterglow wired controller - it uses the same VID as a Gamestop controller
 #define MADCATZ_PID1                            0x4738 // Street Fighter IV FightStick TE
 #define MADCATZ_PID2                            0xF018  //Mad Catz Street Fighter IV SE
+#define ROCKCANDY_WIRED_PID						0xFAFE // Rock candy wired controller
+#define THRUSTMASTER_GPX_WIRED_PID				0x5B02 // Thrustmaster gpx controller
+#define THRUSTMASTER_WHEEL_PID					0x5B00 // Thrustmaster wheel controller
 
 #define XBOX_REPORT_BUFFER_SIZE 14 // Size of the input report buffer
 
@@ -108,7 +113,9 @@ public:
          * @return     Returns true if the device's VID and PID matches this driver.
          */
         virtual bool VIDPIDOK(uint16_t vid, uint16_t pid) {
-                return ((vid == XBOX_VID || vid == MADCATZ_VID || vid == JOYTECH_VID || vid == GAMESTOP_VID || vid == AFTERGLOW_VID) && (pid == XBOX_WIRED_PID || pid == MADCATZ_WIRED_PID || pid == GAMESTOP_WIRED_PID1 || pid == GAMESTOP_WIRED_PID2 || pid == AFTERGLOW_WIRED_PID1 || pid == AFTERGLOW_WIRED_PID2 || pid == JOYTECH_WIRED_PID));
+                return ((vid == XBOX_VID || vid == MADCATZ_VID || vid == JOYTECH_VID || vid == GAMESTOP_VID || vid == AFTERGLOW_VID || vid == ROCKCANDY_VID || vid == THRUSTMASTER_GPX_VID) && 
+				(pid == XBOX_WIRED_PID || pid == MADCATZ_WIRED_PID || pid == GAMESTOP_WIRED_PID1 || pid == GAMESTOP_WIRED_PID2 || pid == AFTERGLOW_WIRED_PID1 || pid == AFTERGLOW_WIRED_PID2 || pid == JOYTECH_WIRED_PID || 
+				pid == ROCKCANDY_WIRED_PID || pid == THRUSTMASTER_GPX_WIRED_PID || pid == THRUSTMASTER_WHEEL_PID));
         };
         /**@}*/
 

--- a/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.h
+++ b/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.h
@@ -35,6 +35,7 @@
 #define MADCATZ_VID                             0x1BAD // For unofficial Mad Catz controllers
 #define JOYTECH_VID                             0x162E // For unofficial Joytech controllers
 #define GAMESTOP_VID                            0x0E6F // Gamestop controller
+#define AFTERGLOW_VID                           0x12AB // Afterglow controller
 #define MADCATZ_VID1                            0x0738 // Gamestop controller
 
 #define XBOX_WIRED_PID                          0x028E // Microsoft 360 Wired controller
@@ -44,8 +45,8 @@
 #define MADCATZ_WIRED_PID                       0xF016 // Mad Catz wired controller
 #define MADCATZ_FIGHTSTICK_PID                  0xF03A // MadCatz FightStick Neo
 #define JOYTECH_WIRED_PID                       0xBEEF // For Joytech wired controller
-#define GAMESTOP_WIRED_PID                      0x0401 // Gamestop wired controller
-#define AFTERGLOW_WIRED_PID                     0x0213 // Afterglow wired controller - it uses the same VID as a Gamestop controller
+#define GAMESTOP_WIRED_PID                      0x0413 // Gamestop wired controller
+#define AFTERGLOW_WIRED_PID                     0x0302 // Afterglow wired controller - it uses the same VID as a Gamestop controller
 #define MADCATZ_PID1                            0x4738 // Street Fighter IV FightStick TE
 #define MADCATZ_PID2                            0xF018  //Mad Catz Street Fighter IV SE
 
@@ -105,7 +106,7 @@ public:
          * @return     Returns true if the device's VID and PID matches this driver.
          */
         virtual bool VIDPIDOK(uint16_t vid, uint16_t pid) {
-                return ((vid == XBOX_VID || vid == MADCATZ_VID || vid == JOYTECH_VID || vid == GAMESTOP_VID) && (pid == XBOX_WIRED_PID || pid == MADCATZ_WIRED_PID || pid == GAMESTOP_WIRED_PID || pid == AFTERGLOW_WIRED_PID || pid == JOYTECH_WIRED_PID));
+                return ((vid == XBOX_VID || vid == MADCATZ_VID || vid == JOYTECH_VID || vid == GAMESTOP_VID || vid == AFTERGLOW_VID) && (pid == XBOX_WIRED_PID || pid == MADCATZ_WIRED_PID || pid == GAMESTOP_WIRED_PID || pid == AFTERGLOW_WIRED_PID || pid == JOYTECH_WIRED_PID));
         };
         /**@}*/
 

--- a/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.h
+++ b/Firmware/ogx360_32u4/lib/USB Host Shield/XBOXUSB.h
@@ -45,8 +45,10 @@
 #define MADCATZ_WIRED_PID                       0xF016 // Mad Catz wired controller
 #define MADCATZ_FIGHTSTICK_PID                  0xF03A // MadCatz FightStick Neo
 #define JOYTECH_WIRED_PID                       0xBEEF // For Joytech wired controller
-#define GAMESTOP_WIRED_PID                      0x0413 // Gamestop wired controller
-#define AFTERGLOW_WIRED_PID                     0x0302 // Afterglow wired controller - it uses the same VID as a Gamestop controller
+#define GAMESTOP_WIRED_PID1                     0x0401 // Gamestop wired controller
+#define GAMESTOP_WIRED_PID2                     0x0413 // Gamestop wired controller
+#define AFTERGLOW_WIRED_PID1                    0x0213 // Afterglow wired controller - it uses the same VID as a Gamestop controller
+#define AFTERGLOW_WIRED_PID2                    0x0302 // Afterglow wired controller - it uses the same VID as a Gamestop controller
 #define MADCATZ_PID1                            0x4738 // Street Fighter IV FightStick TE
 #define MADCATZ_PID2                            0xF018  //Mad Catz Street Fighter IV SE
 
@@ -106,7 +108,7 @@ public:
          * @return     Returns true if the device's VID and PID matches this driver.
          */
         virtual bool VIDPIDOK(uint16_t vid, uint16_t pid) {
-                return ((vid == XBOX_VID || vid == MADCATZ_VID || vid == JOYTECH_VID || vid == GAMESTOP_VID || vid == AFTERGLOW_VID) && (pid == XBOX_WIRED_PID || pid == MADCATZ_WIRED_PID || pid == GAMESTOP_WIRED_PID || pid == AFTERGLOW_WIRED_PID || pid == JOYTECH_WIRED_PID));
+                return ((vid == XBOX_VID || vid == MADCATZ_VID || vid == JOYTECH_VID || vid == GAMESTOP_VID || vid == AFTERGLOW_VID) && (pid == XBOX_WIRED_PID || pid == MADCATZ_WIRED_PID || pid == GAMESTOP_WIRED_PID1 || pid == GAMESTOP_WIRED_PID2 || pid == AFTERGLOW_WIRED_PID1 || pid == AFTERGLOW_WIRED_PID2 || pid == JOYTECH_WIRED_PID));
         };
         /**@}*/
 


### PR DESCRIPTION
VID and PID values for GameStop and Afterglow were not correct. I own one of each controllers and checked the values, GameStop and Afterglow PID is not the same, and the VID values were incorrect for both.

I compiled it and checked and both controllers are working now.

I don't know if there can be multiple VID/PID values depending on the manufacturer or the region or something like that. I'm from Spain and I bought the controllers here, so I added the PIDs and VIDs from my controllers keeping the old ones.