### PR TITLE
Increase delay around reset during USB init

### DIFF
--- a/Firmware/ogx360_32u4/main.cpp
+++ b/Firmware/ogx360_32u4/main.cpp
@@ -158,7 +158,7 @@ int main(void)
 
 	//Init Usb Host Controller
 	digitalWrite(USB_HOST_RESET_PIN, LOW);
-	delay(200);//wait 20ms to reset the IC. Reseting at startup improves reliability in my experience.
+	delay(200);//wait 200ms to reset the IC. Reseting at startup improves reliability in my experience.
 	digitalWrite(USB_HOST_RESET_PIN, HIGH);
 	delay(200); //Settle
 	while (UsbHost.Init() == -1) {

--- a/Firmware/ogx360_32u4/main.cpp
+++ b/Firmware/ogx360_32u4/main.cpp
@@ -158,9 +158,9 @@ int main(void)
 
 	//Init Usb Host Controller
 	digitalWrite(USB_HOST_RESET_PIN, LOW);
-	delay(20);//wait 20ms to reset the IC. Reseting at startup improves reliability in my experience.
+	delay(200);//wait 20ms to reset the IC. Reseting at startup improves reliability in my experience.
 	digitalWrite(USB_HOST_RESET_PIN, HIGH);
-	delay(20); //Settle
+	delay(200); //Settle
 	while (UsbHost.Init() == -1) {
 		digitalWrite(ARDUINO_LED_PIN, !digitalRead(ARDUINO_LED_PIN));
 		delay(500);


### PR DESCRIPTION
I was having an issue with a third party XBox360 Wireless Receiver where I would frequently need to reset the ogx360 board after turning on the XBox in order to get it to initialise. Increasing this delay from 20ms to 200ms has fixed the problem.